### PR TITLE
increase macos default disk size

### DIFF
--- a/makeDarwinImage/default.nix
+++ b/makeDarwinImage/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, writeScript, writeShellScript, runCommand, vncdo, dmg2img, cdrkit, qemu_kvm, python311, tesseract, expect, socat, ruby, xorriso, callPackage, sshpass, openssh, lib, osx-kvm }:
-{ diskSizeBytes ? 50000000000
+{ diskSizeBytes ? 100000000000
 , repeatabilityTest ? false
 }:
 let


### PR DESCRIPTION
There is not enough free disk space (17G vs required 21G) to install Command Line Tools, which are often required by development tools.
This PR increases the default macos disk size from 50Gb to 100Gb.