### PR TITLE
makeDarwinImage: make sshListenAddr configurable

### DIFF
--- a/makeDarwinImage/module.nix
+++ b/makeDarwinImage/module.nix
@@ -32,6 +32,13 @@ in
         VNC will run on port 5901
       '';
     };
+    sshListenAddr = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = lib.mdDoc ''
+        Address on which to listen for forwarding the VM port 22 to the host
+      '';
+    };
     sshPort = lib.mkOption {
       type = lib.types.port;
       default = 2222;
@@ -95,7 +102,7 @@ in
     run-macos = cfg.package.makeRunScript {
       diskImage = cfg.package;
       extraQemuFlags = [ "-vnc ${cfg.vncListenAddr}:${toString cfg.vncDisplayNumber}" ] ++ cfg.extraQemuFlags;
-      inherit (cfg) threads cores sockets mem sshPort;
+      inherit (cfg) threads cores sockets mem sshListenAddr sshPort;
     };
   in lib.mkIf cfg.enable {
     networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [ (5900 + cfg.vncDisplayNumber) cfg.sshPort ];

--- a/makeDarwinImage/run.nix
+++ b/makeDarwinImage/run.nix
@@ -9,6 +9,7 @@
 , threads ? 4
 , cores ? 2
 , sockets ? 1
+, sshListenAddr ? "127.0.0.1"
 , sshPort ? 2222
 , mem ? "6G"
 , diskImage ? (makeDarwinImage {})
@@ -37,7 +38,7 @@ writeShellScriptBin "run-macOS.sh" ''
     -device ich9-intel-hda -device hda-duplex
     -drive id=OpenCoreBoot,if=virtio,snapshot=on,readonly=on,format=qcow2,file="${OpenCoreBoot}"
     -drive id=MacHDD,if=virtio,file="macos-ventura.qcow2",format=qcow2
-    -netdev user,id=net0,hostfwd=tcp::${toString sshPort}-:22 -device virtio-net-pci,netdev=net0,id=net0,mac=52:54:00:c9:18:27
+    -netdev user,id=net0,hostfwd=tcp:${sshListenAddr}:${toString sshPort}-:22 -device virtio-net-pci,netdev=net0,id=net0,mac=52:54:00:c9:18:27
     #-monitor stdio
     -device virtio-vga
     ${lib.concatStringsSep " " extraQemuFlags}


### PR DESCRIPTION
Listening on 0.0.0.0 with admin/admin credentials by default is not very nice.
Let's only listen on IPv4 localhost by default. QEMU does not seem to support listening on an IPv6 address, at least I couldn't figure it out.