### PR TITLE
Nix in Darwin

### DIFF
--- a/makeDarwinImage/default.nix
+++ b/makeDarwinImage/default.nix
@@ -5,7 +5,7 @@
 let
   diskSize = if diskSizeBytes < 40000000000 then throw "diskSizeBytes ${toString diskSizeBytes} too small for macOS" else diskSizeBytes;
 
-  installAssistant-fetched = import <nix/fetchurl.nix> {
+  installAssistant-fetched = fetchurl {
     url = "https://swcdn.apple.com/content/downloads/32/13/052-33049-A_UX3Z28TPLL/702vi772ckrytq1r67eli9zrgsu8jxxoqw/InstallAssistant.pkg";
     sha256 = "sha256-IEJAiqpMNyF053UrW8Lz2r8uk+0LjS8MIs2ERWKqgrw=";
   };


### PR DESCRIPTION
This adds an optionally executed (idempotent) script at the VM boot that installs Nix using the [Determinate Systems' Nix installer](https://github.com/DeterminateSystems/nix-installer) and builds and activates a given `nix-darwin` config (it's also possible installing only Nix without the `nix-darwin` configuration). 

It also adds the needed options in the module. I've been testing it on my NixOS machine with these options:

```nix
{flake, ...}: {
  services.macos-ventura = {
    enable = true;
    cores = 8;
    threads = 8;
    mem = "8G";
    vncListenAddr = "0.0.0.0";
    extraQemuFlags = [ "-nographic" ];
    sshPort = 2021;
    installNix = true;
    stateless = true;
    darwinConfig = flake.darwinConfigurations.foo;
  };
}
```

This is just a draft, I was considering the following improvements:
- apparently [it's possible to perform offline installation](https://github.com/DeterminateSystems/nix-installer/issues/722#issuecomment-1807285995) using the Determinate Systems' installer. It would be nice moving the installation to build time, possibly adding another derivation layer in order to preserve caching.
- at the moment the `nix-darwin` configuration is evaluated externally and its `drv` closure is copied to the VM. At that point the build happens inside `darwin` (otherwise we would need a darwin builder externally) and it may require internet. It should be possible copying both the drv closures and the fixed output realisations from that closure, this way it should be possible building (and activating) the darwin config at build time (build time for the host!). Anyway this would require fetching much more paths than directly building the config on darwin.
- would it make sense adding a NixOS test? I'm not very familiar with those, probably if we implement the first improvement here we can test that nix is installed but how can we test if we can activate a `nix-darwin` configuration? We would need to copy the realisations closure for a `darwin` config i.e. we would need a `darwin` builder to run the tests.