### PR TITLE
makeDarwinImage: explicitly allow access to the Nix Daemon

### DIFF
--- a/makeDarwinImage/module.nix
+++ b/makeDarwinImage/module.nix
@@ -113,6 +113,14 @@ in
     };
   in lib.mkIf cfg.enable {
     networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [ (5900 + cfg.vncDisplayNumber) cfg.sshPort ];
+
+    users.users.macos-ventura = {
+      isSystemUser = true;
+      group = "macos-ventura";
+    };
+    users.groups.macos-ventura = {};
+    nix.settings.allowed-users = [ "macos-ventura" ];
+
     systemd = {
       services.macos-ventura = {
         preStart = lib.optionalString cfg.stateless ''

--- a/makeDarwinImage/run.nix
+++ b/makeDarwinImage/run.nix
@@ -46,9 +46,9 @@ writeShellScriptBin "run-macOS.sh" ''
   )
 
   if [ ! -f macos-ventura.qcow2 ]; then
-    echo "macos-ventura.qcow2 not found, making disk image ./macos-ventura.qcow2"
-    nix-store --realise ${diskImage} --add-root ./macos-ventura-base-image.qcow2
-    ${qemu_kvm}/bin/qemu-img create -b ${diskImage} -F qcow2 -f qcow2 ./macos-ventura.qcow2
+    echo 'The disk image macos-ventura.qcow2 was not found, creating it:'
+    nix-store --realise ${diskImage} --add-root macos-ventura-base-image.qcow2
+    ${qemu_kvm}/bin/qemu-img create -b macos-ventura-base-image.qcow2 -F qcow2 -f qcow2 macos-ventura.qcow2
   fi
 
   # Sometimes plugins like JACK will not be compatible with QEMU from this


### PR DESCRIPTION
Previously we relied on the `nix-settings.allowed-users` option to be kept at the default. If the user sets this setting to `[]`, the `macos-ventura` systemd service wouldn't be allowed to talk to the daemon and the run script would fail to create a garbage collection root. This would cause the base image to be eventually deleted by the garbage collector, leading to an unbootable macOS VM. To fix this, I add a new group and allow it to talk to the Nix daemon.

I first tried to use `SupplementaryGroups` instead but that didn't work, see https://github.com/NixOS/nix/issues/9071.

I also modified the run script to create the `macos-ventura.qcow2` image based on the symlink to the base image instead of using the store path directly. This way, if the `nix-store` command above fails to create the GC root in the future, it will be very obvious.