### PR TITLE
makeDarwinImage: improve the way productVersion is tested

### DIFF
--- a/effects/macos-repeatability-test/default.nix
+++ b/effects/macos-repeatability-test/default.nix
@@ -25,7 +25,7 @@
           export NIX_CONFIG="experimental-features = nix-command flakes"
 
           # How many times to build macOS
-          max_iterations=10
+          max_iterations=3
           iteration=0
 
           function build {


### PR DESCRIPTION
Apparently the version string changed from 13.6 -> 13.7 in https://github.com/MatthewCroughan/NixThePlanet/pull/36 and I never bumped it, so the VM test fails. This PR also improves the reporting of that failure. Now a failure will assert what the found version number was, and what it should be, like this:

```
vm-test-run-macos-ventura> machine # SSH not ready
vm-test-run-macos-ventura> machine # SSH not ready
vm-test-run-macos-ventura> machine # SSH not ready
vm-test-run-macos-ventura> machine # # 127.0.0.1:2021 SSH-2.0-OpenSSH_9.0
vm-test-run-macos-ventura> machine # # 127.0.0.1:2021 SSH-2.0-OpenSSH_9.0
vm-test-run-macos-ventura> machine # # 127.0.0.1:2021 SSH-2.0-OpenSSH_9.0
vm-test-run-macos-ventura> machine # # 127.0.0.1:2021 SSH-2.0-OpenSSH_9.0
vm-test-run-macos-ventura> machine # SSH ready!
vm-test-run-macos-ventura> (finished: must succeed: /nix/store/snhv2z98pwv052cai3fpz2wbf19bydx6-waitForSSH.sh, in 69.19 seconds)
vm-test-run-macos-ventura> subtest: Check that the macOS Ventura machine returns ProductVersion 13.6 via SSH
vm-test-run-macos-ventura> machine: must succeed: /nix/store/x2py2hhs16l2dwbbwqv9pw6c6nzqdmhy-getProductVersion.sh
vm-test-run-macos-ventura> machine # Warning: Permanently added '[127.0.0.1]:2021' (ED25519) to the list of known hosts.
vm-test-run-macos-ventura> (finished: must succeed: /nix/store/x2py2hhs16l2dwbbwqv9pw6c6nzqdmhy-getProductVersion.sh, in 7.01 seconds)
vm-test-run-macos-ventura> Received ProductVersion: 13.7
vm-test-run-macos-ventura> Test "Check that the macOS Ventura machine returns ProductVersion 13.6 via SSH" failed with error: "Expected '13.6', but got '13.7
vm-test-run-macos-ventura> '"
vm-test-run-macos-ventura> cleanup
vm-test-run-macos-ventura> kill machine (pid 9)
vm-test-run-macos-ventura> machine # qemu-kvm: terminating on signal 15 from pid 6 (/nix/store/5k91mg4qjylxbfvrv748smfh51ppjq0g-python3-3.11.6/bin/python3.11)
vm-test-run-macos-ventura> (finished: cleanup, in 0.05 seconds)
vm-test-run-macos-ventura> kill vlan (pid 7)
error: builder for '/nix/store/3zcb38qr5qk6nr01bgbmxnwr4jsnncmb-vm-test-run-macos-ventura.drv' failed with exit code 1;
```

