### PR TITLE
makeDarwinImage: use startosinstall, less OCR/VNC

### DIFF
--- a/makeDarwinImage/default.nix
+++ b/makeDarwinImage/default.nix
@@ -107,26 +107,6 @@ let
     expect "80x24"
     exec ${qemuSendKeys} "sh /Volumes/run_offline/run_offline.sh<kp_enter>"
 
-    ${sendUser "Welcome to macOS"}
-    expect "Continue"
-    exec ${qemuSendMouse} 995 720
-
-    ${sendUser "Agree to EULA"}
-    expect "Disagree"
-    exec ${qemuSendMouse} 995 720
-
-    ${sendUser "Really Agree to EULA"}
-    expect "have read and agree to the"
-    exec ${qemuSendMouse} 1000 525
-
-    ${sendUser "Select macOS as install disk"}
-    expect "Select the disk where you want to install macOS"
-    exec ${qemuSendMouse} 780 550
-
-    ${sendUser "Continue"}
-    expect "Continue"
-    exec ${qemuSendMouse} 1000 710
-
     ${sendUser "Select Your Country or Region"}
     expect "Select Your Country or Region"
     exec ${qemuSendKeys} "united states<delay><shift-tab><delay><spc>"

--- a/makeDarwinImage/osx-kvm-additions/scripts/run_offline.sh
+++ b/makeDarwinImage/osx-kvm-additions/scripts/run_offline.sh
@@ -9,4 +9,4 @@ cp -R "/Install macOS Ventura.app" private/tmp
 cd "private/tmp/Install macOS Ventura.app"
 mkdir Contents/SharedSupport
 cp -R /Volumes/InstallAssistant/InstallAssistant.pkg Contents/SharedSupport/SharedSupport.dmg
-./Contents/MacOS/InstallAssistant_springboard
+./Contents/Resources/startosinstall --agreetolicense --nointeraction --volume /Volumes/macOS


### PR DESCRIPTION
May improve speed of installation due to less waiting/sleeping and improve reliability of the installation process.