### PR TITLE
Add flake compat for flakeless usage (with npins for instance)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+# WARNING: You should use `builtins.getFlake` instead of this where possible. This file will go away when nix's flakes feature becomes stable.
+(import
+  (
+    fetchTarball {
+      url = "https://github.com/nix-community/flake-compat/archive/38fd3954cf65ce6faf3d0d45cd26059e059f07ea.tar.gz";
+      sha256 = "sha256-FrlieJH50AuvagamEvWMIE6D2OAnERuDboFDYAED/dE=";
+    }
+  )
+  { src = ./.; }).defaultNix


### PR DESCRIPTION
Hi,

I would like to use this in a flakeless environment, hence the addition.

I've tested this, and it works fine on my end, I'm not sure however if this is the best/cleanest way to add `flake-compat`.