### PR TITLE
update macOS URL

### DIFF
--- a/makeDarwinImage/default.nix
+++ b/makeDarwinImage/default.nix
@@ -6,9 +6,9 @@ let
   diskSize = if diskSizeBytes < 40000000000 then throw "diskSizeBytes ${toString diskSizeBytes} too small for macOS" else diskSizeBytes;
 
   installAssistant-fetched = import <nix/fetchurl.nix> {
-    # Version 13.7.4 (22H420)
-    url = "https://swcdn.apple.com/content/downloads/08/22/072-83845-A_XJNKWES8K3/95bsibbbgdt0eyfr278z60061tw15x7g40/InstallAssistant.pkg";
-    sha256 = "sha256-iw7unRm3iKcwVbpJbQ740Fsg6rVAR88fDGXuB01zS9g=";
+    # Version 13.7.8 (22H730)
+    url = "https://swcdn.apple.com/content/downloads/09/46/093-22004-A_QNZEDC334I/phigx2zvoggml6sh79my4y51fnvgy8hix4/InstallAssistant.pkg";
+    sha256 = "sha256-WloZff6HV0EZv83RI9tWdhOZms1anTBMk2KAoxyw58I=";
   };
 
   installAssistant-iso = runCommand "InstallAssistant.iso" { buildInputs = [ cdrkit ]; } ''


### PR DESCRIPTION
The package can no longer be downloaded at the old URL:

```
user@desktop ~/d/NixThePlanet (master)> nix run .#macos-ventura
error: Cannot build '/nix/store/jqdb7z26ywwmsj7dlhihva6maz2f1z25-InstallAssistant.pkg.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/akqwnwmbvzxfa91gfpsa8m0n9jxgj1vx-InstallAssistant.pkg
       Last 4 log lines:
       > error:
       >        … writing file '/nix/store/akqwnwmbvzxfa91gfpsa8m0n9jxgj1vx-InstallAssistant.pkg'
       >
       >        error: unable to download 'https://swcdn.apple.com/content/downloads/08/22/072-83845-A_XJNKWES8K3/95bsibbbgdt0eyfr278z60061tw15x7g40/InstallAssistant.pkg': HTTP error 403
       For full logs, run:
         nix log /nix/store/jqdb7z26ywwmsj7dlhihva6maz2f1z25-InstallAssistant.pkg.drv
error: Cannot build '/nix/store/sgxg2zvq0k15z7b1ricjd6m92ima2d29-InstallAssistant.iso.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/lr3ry6r5kjwihi6jk50shs6g7gixn9gc-InstallAssistant.iso
error: Cannot build '/nix/store/9y19xblkifzpalx1lwiizgngsmk3hy6r-mac_hdd_ng.qcow2.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/anvbqrvd1ikf5ksxmy5knvdkdhknywp7-mac_hdd_ng.qcow2
error: Cannot build '/nix/store/pcvchqx31rv4q2ifnryaqrwylqig520a-run-macOS.sh.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/60b4lbqcc0gh5dkw4r9zg2rwz8p9b7k8-run-macOS.sh
```

Updated to latest Ventura URL and updated hash.